### PR TITLE
Add optional prop for disabling unescape of node values

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,7 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface XmlViewerComponent {
+        "useUnescapedNodeValue": boolean;
         "xml": string;
     }
 }
@@ -23,6 +24,7 @@ declare global {
 }
 declare namespace LocalJSX {
     interface XmlViewerComponent {
+        "useUnescapedNodeValue"?: boolean;
         "xml"?: string;
     }
     interface IntrinsicElements {

--- a/src/components/xml-viewer-component/xml-viewer-component.tsx
+++ b/src/components/xml-viewer-component/xml-viewer-component.tsx
@@ -16,7 +16,7 @@ export class XmlViewerComponent {
 
   @Prop() xml: string;
 
-  @Prop() unscapeNodeValue: boolean = true;
+  @Prop() useUnescapedNodeValue: boolean = true;
 
   componentDidLoad() {
   }
@@ -26,8 +26,8 @@ export class XmlViewerComponent {
     this.render();
   }
 
-  @Watch('unscapeNodeValue')
-  unscapeNodeValuePropChanged() {
+  @Watch('useUnescapedNodeValue')
+  useUnescapedNodeValuePropChanged() {
     this.render();
   }
 
@@ -60,7 +60,7 @@ export class XmlViewerComponent {
       return null;
     }
 
-    const val = this.unscapeNodeValue ? unescape(nodeValue.trim()) : nodeValue.trim();
+    const val = this.useUnescapedNodeValue ? unescape(nodeValue.trim()) : nodeValue.trim();
 
     if (val.length === 0) {
       return null;

--- a/src/components/xml-viewer-component/xml-viewer-component.tsx
+++ b/src/components/xml-viewer-component/xml-viewer-component.tsx
@@ -16,11 +16,18 @@ export class XmlViewerComponent {
 
   @Prop() xml: string;
 
+  @Prop() unscapeNodeValue: boolean = true;
+
   componentDidLoad() {
   }
 
   @Watch('xml')
   xmlPropChanged() {
+    this.render();
+  }
+
+  @Watch('unscapeNodeValue')
+  unscapeNodeValuePropChanged() {
     this.render();
   }
 
@@ -53,7 +60,7 @@ export class XmlViewerComponent {
       return null;
     }
 
-    const val = unescape(nodeValue.trim());
+    const val = this.unscapeNodeValue ? unescape(nodeValue.trim()) : nodeValue.trim();
 
     if (val.length === 0) {
       return null;


### PR DESCRIPTION
Unescaping all node values can cause issues if the source XML contains content such as "%dd/MM/yyyy%"

We don't always have the ability to modify the source XML, so adding an optional property to turn off the unescaping allows users to use the component with content containing % characters